### PR TITLE
display only one line per package

### DIFF
--- a/bin/build_index.dart
+++ b/bin/build_index.dart
@@ -39,17 +39,22 @@ void main() {
 
   packageBuildInfoDataStore.fetchBuilt()
   .then((List<PackageBuildInfo> packageBuildInfos) {
-    Map renderData = {'docsUrls': []};
+    Map renderData = {'packages': []};
+    Map packages = {};
 
-    renderData['docsUrls'].addAll(packageBuildInfos.map((packageBuildInfo) {
-      return {
+    packageBuildInfos.forEach((packageBuildInfo) {
+      final package = packages.putIfAbsent(packageBuildInfo.name, () => {
         "name": packageBuildInfo.name,
+        "versions": [],
+      });
+      package['versions'].insert(0, {
         "version": packageBuildInfo.version,
         "url": 'http://www.dartdocs.org/documentation/'
           '${packageBuildInfo.name}/${packageBuildInfo.version}/index.html#'
           '${packageBuildInfo.name}'
-      };
-    }).toList());
+      });
+    });
+    renderData['packages'].addAll(packages.values);
 
     File dartDocsIndex = new File("dartdocs_index.html");
     dartDocsIndex.writeAsStringSync(buildDartDocsIndexHtml(renderData));

--- a/bin/dartdocs_index.html.mustache
+++ b/bin/dartdocs_index.html.mustache
@@ -3,8 +3,18 @@
 <title>www.dartdocs.org</title>
 </head>
 <body>
-{{#docsUrls}}
-  <a href="{{url}}">{{name}} {{version}}</a><br/>
-{{/docsUrls}}
+  <table>
+    <caption>Packages</caption>
+    <tr>
+      <th>Name</th>
+      <th>Versions</th>
+    </tr>
+{{#packages}}
+    <tr>
+      <td>{{name}}</td>
+      <td>{{#versions}}<a href="{{url}}">{{version}}</a> {{/versions}}</td>
+    </tr>
+{{/packages}}
+  </table>
 </body>
 </html>


### PR DESCRIPTION
Here is a proposal to display one line per package with the most recent version first. Something like :

| Name | Versions |
| --- | --- |
| a | 2.3.0 - 2.2.2 - 2.2.1 - 2.2.0 |
| b | 1.2.0 - 1.1.0 - 1.0.0 |
| c | 1.0.0 |

What do you think ?
